### PR TITLE
Fix sync issue by splitting images

### DIFF
--- a/deployment/Tiltfile
+++ b/deployment/Tiltfile
@@ -9,10 +9,28 @@ k8s_resource(
 )
 
 docker_build(
- 'spryker-image',
+ 'spryker-image-base',
  '..',
  target='spryker',
  dockerfile='Dockerfile',
+ live_update=[
+   sync('..', '/data'),
+ ],
+)
+
+docker_build(
+ 'spryker-image',
+ '..',
+ dockerfile_contents='FROM spryker-image-base',
+ live_update=[
+   sync('..', '/data'),
+ ],
+)
+
+docker_build(
+ 'spryker-image-tasks',
+ '..',
+ dockerfile_contents='FROM spryker-image-base',
  live_update=[
    sync('..', '/data'),
  ],

--- a/deployment/Tiltfile
+++ b/deployment/Tiltfile
@@ -13,9 +13,6 @@ docker_build(
  '..',
  target='spryker',
  dockerfile='Dockerfile',
- live_update=[
-   sync('..', '/data'),
- ],
 )
 
 docker_build(

--- a/deployment/tests/code-sniffer.yaml
+++ b/deployment/tests/code-sniffer.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
             containers:
                 - name: tests
-                  image: spryker-image
+                  image: spryker-image-tasks
                   command:
                       - bash
                       - -c


### PR DESCRIPTION
Split `spryker-image` into `spryker-image-base`, `spryker-image`, and `spryker-image-tasks`.

The original sync problem occurs because the `spryker-image` is shared between two resources. When any one of those containers' resources is disabled, the file watch on the image and its live updates is disabled, and so no live updates are performed for any resources that use that image.

In order to get the desired sync behavior, each resource is given its own image, inheriting from a common -base image. This isolates disabling one resource from affecting updates to any other resources, because no image is shared.

We can certainly have a discussion that the original behavior is an outright bug. It might be helpful to look at it as a limitation of the enable/disable feature as currently implemented in that you need to design your image hierarchy around it in order to have the functionality you want.
